### PR TITLE
Add trailing newlines to generated Android XML files

### DIFF
--- a/src/processors/android/adaptiveIconProcessor.js
+++ b/src/processors/android/adaptiveIconProcessor.js
@@ -132,7 +132,8 @@ function generateAdaptiveIconXML(flavorName, iconXMLName) {
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>`;
+</adaptive-icon>
+`;
 
   fs.writeFileSync(xml, xmlContent);
 }

--- a/src/processors/android/splashScreenProcessor.js
+++ b/src/processors/android/splashScreenProcessor.js
@@ -190,7 +190,8 @@ async function generateColorsXML(flavorName, backgroundColor) {
     const colorsContent = `<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="splashscreen_background">${backgroundColor}</color>
-</resources>`;
+</resources>
+`;
 
     fs.writeFileSync(colors, colorsContent);
   }
@@ -216,7 +217,8 @@ async function generateSplashScreenXML(flavorName) {
       android:src="@drawable/splashscreen_image"
     />
   </item>
-</layer-list>`;
+</layer-list>
+`;
 
   fs.writeFileSync(xml, xmlContent);
 }


### PR DESCRIPTION
## Description
This PR ensures that all Android XML files generated by the flavorizer tool have a trailing newline at the end. This is a best practice that helps prevent issues with version control systems and text editors, and maintains consistency across the codebase.

## Changelog
* Add trailing newlines to all generated XML files:
  * android/app/src/[brand]/res/drawable/splashscreen.xml
  * android/app/src/[brand]/res/mipmap-anydpi-v26/ic_launcher.xml
  * android/app/src/[brand]/res/mipmap-anydpi-v26/ic_launcher_round.xml
  * android/app/src/[brand]/res/values/colors.xml

## Steps to test
1. Create a new expo project:
```bash
npx create-expo-app test-flavorizer
cd test-flavorizer
```

2. If you have expo-flavorizer installed globally, unlink it:
```bash
yarn global remove @reservamos/expo-flavorizer
# or
npm uninstall -g @reservamos/expo-flavorizer
```

3. Clone and link the local version:
```bash
cd ../
git clone https://github.com/reservamos/expo-flavorizer.git
cd expo-flavorizer
yarn install
yarn link
cd ../test-flavorizer
yarn link "@reservamos/expo-flavorizer"
```

4. Initialize flavorizer:
```bash
npx flavorizer init
```

5. Add a test flavor to flavorizer.config.json:
```json
{
  "flavors": [
    {
      "flavorName": "test",
      "appName": "Test App",
      "defaultIcon": "assets/icon.png",
      "android": {
        "applicationId": "com.example.test",
        "adaptiveIcon": {
          "background": "assets/icon-background.png",
          "foreground": "assets/icon-foreground.png"
        },
        "splash": {
          "image": "assets/splash.png",
          "backgroundColor": "#FFFFFF"
        }
      }
    }
  ],
  "instructions": [
    "android:androidManifest",
    "android:buildGradle",
    "android:icons",
    "android:splashScreen"
  ]
}
```

6. Create placeholder assets:
```bash
mkdir -p assets
touch assets/icon.png assets/icon-background.png assets/icon-foreground.png assets/splash.png
```

7. Apply the flavorizer:
```bash
npx flavorizer apply
```

8. Verify that all generated XML files have a trailing newline:
```bash
# Check splashscreen.xml
cat android/app/src/test/res/drawable/splashscreen.xml | tail -c 1

# Check ic_launcher.xml
cat android/app/src/test/res/mipmap-anydpi-v26/ic_launcher.xml | tail -c 1

# Check ic_launcher_round.xml
cat android/app/src/test/res/mipmap-anydpi-v26/ic_launcher_round.xml | tail -c 1

# Check colors.xml
cat android/app/src/test/res/values/colors.xml | tail -c 1
```

Each command should output a newline character (`\n`).

9. Clean up after testing:
```bash
yarn unlink "@reservamos/expo-flavorizer"
cd ../expo-flavorizer
yarn unlink
```
